### PR TITLE
Updates find_reported_twitch_user function in both warnings (where it…

### DIFF
--- a/app/controllers/revocations_controller.rb
+++ b/app/controllers/revocations_controller.rb
@@ -70,12 +70,12 @@ class RevocationsController < ApplicationController
     
     def find_reported_twitch_user
       # Check if reported_twitch_name exists on Twitch
-      response = HTTParty.get(URI.escape("#{ENV['TWITCH_API_BASE_URL']}/users?login=#{@report.reported_twitch_name}"), headers: {Accept: 'application/vnd.twitchtv.v5+json', "Client-ID": ENV['TWITCH_CLIENT_ID']})
+      response = HTTParty.get(URI.escape("#{ENV['TWITCH_API_BASE_URL']}/users?login=#{@report.reported_twitch_name}"), headers: {"Client-ID": ENV['TWITCH_CLIENT_ID'], "Authorization": "Bearer #{TwitchToken.first.valid_token!}"})
       
-      if response["users"].blank?
+      if response["data"].blank?
        @reported_twitch_user = nil
       else
-        @reported_twitch_user = response["users"][0]["_id"]
+        @reported_twitch_user = response["data"][0]["id"]
       end
     end
 

--- a/app/controllers/warnings_controller.rb
+++ b/app/controllers/warnings_controller.rb
@@ -62,13 +62,12 @@ class WarningsController < ApplicationController
     
     def find_reported_twitch_user
       # Check if reported_twitch_name exists on Twitch
-      # TODO: Roll over to Helix v6 API endpoint when they are built
-      response = HTTParty.get(URI.escape("#{ENV['TWITCH_API_V5_BASE_URL']}/users?login=#{@report.reported_twitch_name}"), headers: {Accept: 'application/vnd.twitchtv.v5+json', "Client-ID": ENV['TWITCH_CLIENT_ID']})
+      response = HTTParty.get(URI.escape("#{ENV['TWITCH_API_BASE_URL']}/users?login=#{@report.reported_twitch_name}"), headers: {"Client-ID": ENV['TWITCH_CLIENT_ID'], "Authorization": "Bearer #{TwitchToken.first.valid_token!}"})
       
-      if response["users"].blank?
+      if response["data"].blank?
        @reported_twitch_user = nil
       else
-        @reported_twitch_user = response["users"][0]["_id"]
+        @reported_twitch_user = response["data"][0]["id"]
       end
     end
 


### PR DESCRIPTION
… was using the old API) and revocations (where it wasn't udpated at all) controllers. This function is shared across three controllers and should be moved to a controller concern to be DRY and avoid bugs like this in the future.